### PR TITLE
Updating service definitions for Pimple 2

### DIFF
--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -8,7 +8,7 @@ class Services implements ServicesInterface
 {
 	public function registerServices($services)
 	{
-		$services['filesystem.stream_wrapper_mapping'] = $services->extend('filesystem.stream_wrapper_mapping', function($mapping, $services) {
+		$services->extend('filesystem.stream_wrapper_mapping', function($mapping, $services) {
 			$baseDir = $services['app.loader']->getBaseDir();
 			// Maps cog://ms/file/* to /files/* (in the installation)
 			$mapping["/^\/ms\/file\/(.*)/us"] = $baseDir.'files/$1';


### PR DESCRIPTION
See https://github.com/messagedigital/cog/pull/323

I made a bunch of the services factory services (they were shared before) for consistency with the rest of the system. Decorators don't need to be shared.
