### PR TITLE
set width of file in file manager to 500px

### DIFF
--- a/resources/view/detail.html.twig
+++ b/resources/view/detail.html.twig
@@ -13,7 +13,7 @@
 			<div class="content">
 				<div class="column">
 					{% if file.isTypeImage() %}
-						{{ getResizedImage(file, null, null, {'class': 'file'}) }}
+						{{ getResizedImage(file, null, 500, {'class': 'file'}) }}
 					{% else %}
 						<img src="/cogules/Message:Mothership:ControlPanel/images/document.gif" alt="{{ file.altText }}" class="file" />
 					{% endif %}
@@ -56,9 +56,9 @@
 								{% endif %}
 							</tbody>
 						</table>
-					</div>		
+					</div>
 				</div>
-			</div>	
+			</div>
 		</div>
 		<form action="{{ url('ms.cp.file_manager.delete', {fileID: file.id}) }}" method="post" data-confirm="{{ 'ms.file_manager.delete.confirm'|trans }}" >
 			<input type="hidden" name="_method" value="DELETE">


### PR DESCRIPTION
Images weren't rendering in the file detail page as both the width and height were set to automatically work themselves out. Set it to 500px as that's what it was before
