### PR TITLE
Allow `File` to be serialized safely

### DIFF
--- a/src/File/File.php
+++ b/src/File/File.php
@@ -4,6 +4,7 @@ namespace Message\Mothership\FileManager\File;
 
 use Message\ImageResize\ResizableInterface;
 
+use Message\Cog\Filesystem\File as FileSystemFile;
 use Message\Cog\ValueObject\Authorship;
 
 /**
@@ -30,9 +31,49 @@ class File implements ResizableInterface
 
 	public $file;
 
+	protected $_filePath;
+
+	/**
+	 * Constructor.
+	 */
 	public function __construct()
 	{
 		$this->authorship = new Authorship;
+	}
+
+	/**
+	 * Magic sleep method. Called before this object is serialized.
+	 *
+	 * Here, we drop the instance of `Filesystem\File` in Cog because it extends
+	 * `SplFileInfo` so it cannot be serialized. We save the file path so we can
+	 * re-instantiate it on `__wakeup()`.
+	 *
+	 * @return array Property names to include in serialization (all except for
+	 *               `file`)
+	 */
+	public function __sleep()
+	{
+		// Save the file path
+		$this->_filePath = $this->file->getRealPath();
+
+		// Get all properties for this object
+		$vars = get_object_vars($this);
+
+		// Remove the `file` property
+		unset($vars['file']);
+
+		return array_keys($vars);
+	}
+
+	/**
+	 * Magic wake up method. Called after this object is unserialized.
+	 *
+	 * Here, we rebuild the instance of `Filesystem\File` in Cog from the saved
+	 * file path.
+	 */
+	public function __wakeup()
+	{
+		$this->file = new FileSystemFile($this->_filePath);
 	}
 
 	public function getUrl()


### PR DESCRIPTION
#### What does this do?

We had problems with serializing `File` because it contained an instance of `Message\Cog\Filesystem\File` which extends `SplFileInfo` which cannot be serialized.

This PR fixes this by not including that property in the serialization list and saving the file path to rebuild it on `__wakeup()` instead.
#### How should this be manually tested?

Try serializing a `File` instance and then un-serializing it. All should be well, with no errors.
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
