### PR TITLE
Fixed delete confirmation showing as translation key

### DIFF
--- a/resources/view/detail.html.twig
+++ b/resources/view/detail.html.twig
@@ -60,7 +60,7 @@
 				</div>
 			</div>
 		</div>
-		<form action="{{ url('ms.cp.file_manager.delete', {fileID: file.id}) }}" method="post" data-confirm="{{ 'ms.file_manager.delete.confirm'|trans }}" >
+		<form action="{{ url('ms.cp.file_manager.delete', {fileID: file.id}) }}" method="post" data-confirm="{{ 'ms.file_manager.detail.delete.confirm'|trans }}" >
 			<input type="hidden" name="_method" value="DELETE">
 			<button name="delete[delete]" value="delete" id="delete" type="submit" class="button small delete">{{ 'ms.file_manager.detail.buttons.delete'|trans }}</button>
 		</form>


### PR DESCRIPTION
#### What does this do?

Fixes #66 by correcting the translation key.
#### How should this be manually tested?

Go to file manager, try to delete a file, see whether the confirmation text is a translation key or actual words that make sense.

Looked like this before (see issue description for details):
https://www.dropbox.com/s/znzc1om1x8bu6kw/Screenshot%202014-06-11%2016.04.11.png

Should look like this now:
![image](https://cloud.githubusercontent.com/assets/4313088/3259249/d8f3e8fe-f241-11e3-811c-67d93dbae1e5.png)
#### Related PRs / Issues / Resources?

Issue: #66 
#### Anything else to add? (Screenshots, background context, etc)
