### PR TITLE
Catch exceptions on the file sync script gracefully

### DIFF
--- a/src/Task/SyncFiles.php
+++ b/src/Task/SyncFiles.php
@@ -33,6 +33,13 @@ class SyncFiles extends Task
 	protected $_bannedFiles = [];
 
 	/**
+	 * Array of errors thrown
+	 *
+	 * @var array
+	 */
+	protected $_errors = [];
+
+	/**
 	 * @var Finder
 	 */
 	protected $_finder;
@@ -43,7 +50,9 @@ class SyncFiles extends Task
 			->_loadFiles()
 			->_addToSystem()
 			->_reportExistingFiles()
-			->_reportBannedFiles();
+			->_reportBannedFiles()
+			->_reportErrors()
+		;
 	}
 
 	protected function _setFinder()
@@ -83,7 +92,10 @@ class SyncFiles extends Task
 				$this->_existingFiles[$e->getFileId()] = $file->getFilename();
 			}
 			catch (Exception\BannedType $e){
-				$this->_bannedTypes[] = $file->getFilename();
+				$this->_bannedFiles[] = $file->getFilename();
+			}
+			catch (\Exception $e) {
+				$this->_errors[] = $e->getMessage();
 			}
 		}
 
@@ -103,6 +115,16 @@ class SyncFiles extends Task
 	{
 		foreach ($this->_bannedFiles as $name) {
 			$this->writeln("<error>" . $name .  " is a banned file type</error>");
+		}
+
+		return $this;
+	}
+
+	protected function _reportErrors()
+	{
+		$this->writeln("<error>The following exceptions were thrown!</error>");
+		foreach ($this->_errors as $error) {
+			$this->writeln("<error>- " . $error . "</error>");
 		}
 	}
 }


### PR DESCRIPTION
#### What does this do?

Syncing files on Tonic and RSAR was breaking when it was trying to duplicate rows. There's a bigger underlying issue here that requires investigation, but this stops the file sync from breaking when this happens.
#### How should this be manually tested?

Download the Tonic images and the live database and run:

`bin/cog task:run file_manager:sync_files --env=local-[your name]`

Some rows will be duplicates, but the script will continue to run regardless and report the errors at the end
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
