### PR TITLE
Replace File\Loader with File\FileLoader

### DIFF
--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -2,6 +2,7 @@
 
 namespace Message\Mothership\FileManager\Bootstrap;
 
+use Message\Mothership\FileManager;
 use Message\Cog\Bootstrap\ServicesInterface;
 
 class Services implements ServicesInterface
@@ -17,14 +18,15 @@ class Services implements ServicesInterface
 		});
 
 		$services['file_manager.file.loader'] = $services->factory(function($c) {
-			return new \Message\Mothership\FileManager\File\Loader(
+			return new FileManager\File\FileLoader(
 				'Locale class',
-				$c['db.query']
+				$c['db.query.builder.factory'],
+				$c['file_manager.tag.loader']
 			);
 		});
 
 		$services['file_manager.file.create'] = $services->factory(function($c) {
-			return new \Message\Mothership\FileManager\File\Create(
+			return new FileManager\File\Create(
 				$c['file_manager.file.loader'],
 				$c['db.query'],
 				$c['event.dispatcher'],
@@ -33,7 +35,7 @@ class Services implements ServicesInterface
 		});
 
 		$services['file_manager.file.edit'] = $services->factory(function($c) {
-			return new \Message\Mothership\FileManager\File\Edit(
+			return new FileManager\File\Edit(
 				$c['db.query'],
 				$c['event.dispatcher'],
 				$c['user.current']
@@ -41,15 +43,19 @@ class Services implements ServicesInterface
 		});
 
 		$services['file_manager.file.delete'] = $services->factory(function($c) {
-			return new \Message\Mothership\FileManager\File\Delete(
+			return new FileManager\File\Delete(
 				$c['db.query'],
 				$c['event.dispatcher'],
 				$c['user.current']
 			);
 		});
 
+		$services['file_manager.tag.loader'] = function($c) {
+			return new FileManager\File\TagLoader($c['db.query.builder.factory']);
+		};
+
 		$services->extend('field.collection', function($fields, $c) {
-			$fields->add(new \Message\Mothership\FileManager\FieldType\File(
+			$fields->add(new FileManager\FieldType\File(
 				$c['file_manager.file.loader'],
 				$c['translator']
 			));

--- a/src/File/FileLoader.php
+++ b/src/File/FileLoader.php
@@ -24,12 +24,12 @@ class FileLoader extends Loader implements FileLoaderInterface
 	/**
 	 * @var DB\QueryBuilderFactory
 	 */
-	private $_queryBuilderFactory;
+	protected $_queryBuilderFactory;
 
 	/**
 	 * @var TagLoader
 	 */
-	private $_tagLoader;
+	protected $_tagLoader;
 
 	/**
 	 * @var bool
@@ -39,7 +39,7 @@ class FileLoader extends Loader implements FileLoaderInterface
 	/**
 	 * @var DB\QueryBuilder
 	 */
-	private $_queryBuilder;
+	protected $_queryBuilder;
 
 	/**
 	 * var to toggle the loading of deleted files

--- a/src/File/FileLoader.php
+++ b/src/File/FileLoader.php
@@ -221,17 +221,6 @@ class FileLoader extends Loader implements FileLoaderInterface
 
 		return $this;
 	}
-	/**
-	 * @deprecated   Do not load tags from the file loader, use the TagLoader instead
-	 *
-	 * Gets the tags for a file
-	 * @param  File      $file file to load tags for
-	 * @return array     tags for file as an array
-	 */
-	public function getTagsForFile(File $file)
-	{
-		return $this->_tagLoader->getByFile($file);
-	}
 
 	/**
 	 * Sets the query builder with the appropriate SELECT and FROM statement
@@ -325,16 +314,4 @@ class FileLoader extends Loader implements FileLoaderInterface
 
 		return count($files) == 1 && !$this->_returnAsArray ? array_shift($files) : $files;
 	}
-
-	/**
-	 * @deprecated  Do not load tags from the file loader, use the tag loader directly instead
-	 *
-	 * @param File $file
-	 * @return array
-	 */
-	protected function _loadTags(File $file)
-	{
-		return $this->_tagLoader->getByFile($file);
-	}
-
 }

--- a/src/File/FileLoader.php
+++ b/src/File/FileLoader.php
@@ -162,15 +162,17 @@ class FileLoader extends Loader implements FileLoaderInterface
 
 		// Loop over the terms and add them to an array to implode in the query
 		foreach ($terms as $key => $term) {
-			$whereName[]  = ' name LIKE ?s';
-			$whereTag[]   = ' tag_name LIKE ?s';
+			$whereName[]  = ' file.name LIKE ?s';
+			$whereTag[]   = ' file_tag.tag_name LIKE ?s';
 			$terms[$key] = '%' . trim($term) . '%';
 		}
 
 		$this->_setQueryBuilder();
+
 		$this->_queryBuilder
-			->where('(' . implode(' OR ' . $whereName) . ')', $terms)
-			->where('(' . implode(' OR ' . $whereTag) . ')', $terms, false)
+			->leftJoin('file_tag', 'file.file_id = file_tag.file_id')
+			->where('(' . implode(' OR ', $whereName) . ')', $terms)
+			->where('(' . implode(' OR ', $whereTag) . ')', $terms, false)
 		;
 
 		$this->_returnAsArray = true;

--- a/src/File/FileLoader.php
+++ b/src/File/FileLoader.php
@@ -1,0 +1,340 @@
+<?php
+
+namespace Message\Mothership\FileManager\File;
+
+use Message\User;
+use Message\Cog\DB;
+use Message\Cog\ValueObject\DateTimeImmutable;
+use Message\Cog\Filesystem\File as FileSystemFile;
+use Message\Cog\DB\Result;
+
+/**
+ * Class FileLoader
+ * @package Message\Mothership\FileManager\File
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ */
+class FileLoader extends Loader implements FileLoaderInterface
+{
+	/**
+	 * @var
+	 */
+	protected $_locale;
+
+	/**
+	 * @var DB\QueryBuilderFactory
+	 */
+	private $_queryBuilderFactory;
+
+	/**
+	 * @var TagLoader
+	 */
+	private $_tagLoader;
+
+	/**
+	 * @var bool
+	 */
+	protected $_returnAsArray;
+
+	/**
+	 * @var DB\QueryBuilder
+	 */
+	private $_queryBuilder;
+
+	/**
+	 * var to toggle the loading of deleted files
+	 *
+	 * (default value: false)
+	 *
+	 * @var bool
+	 */
+	protected $_loadDeleted = false;
+
+	public function __construct(/*\Locale*/ $locale, DB\QueryBuilderFactory $queryBuilderFactory, TagLoader $tagLoader)
+	{
+		$this->_locale              = $locale;
+		$this->_queryBuilderFactory = $queryBuilderFactory;
+		$this->_tagLoader           = $tagLoader;
+	}
+
+	/**
+	 * Return an array of, or singular File object
+	 *
+	 * @param  int|array $fileIDs
+	 * @return array|File 	File object
+	 */
+	public function getByID($fileIDs)
+	{
+		if (!is_array($fileIDs)) {
+			$fileIDs = [$fileIDs];
+			$this->_returnAsArray = false;
+		} else {
+			$this->_returnAsArray = true;
+		}
+
+		$this->_setQueryBuilder();
+		$this->_queryBuilder
+			->where('file.file_id IN (?ji)', [$fileIDs])
+		;
+
+		return $this->_loadFromQuery();
+	}
+
+	/**
+	 * Returns all the files of a certain file type id
+	 *
+	 * @param  int 	$typeID
+	 * @return array|File 	Array of File objects, or a single File object
+	 */
+	public function getByType($typeID)
+	{
+		$this->_setQueryBuilder();
+		$this->_queryBuilder
+			->where('file.type_id = ?i', [$typeID])
+		;
+
+		$this->_returnAsArray = true;
+
+		return $this->_loadFromQuery();
+	}
+
+	/**
+	 * Load files with a given filename
+	 *
+	 * @param $filename
+	 * @return false|File
+	 */
+	public function getByFilename($filename)
+	{
+		if (!is_string($filename)) {
+			throw new \InvalidArgumentException('Filename must be a string, ' . gettype($filename) . ' given');
+		}
+
+		$this->_setQueryBuilder();
+		$this->_queryBuilder
+			->where('file.name = ?s', [$filename])
+		;
+
+		$this->_returnAsArray = false;
+
+		return $this->_loadFromQuery();
+	}
+
+	/**
+	 * Load files with an extension
+	 *
+	 * @param $ext
+	 * @return false|File
+	 */
+	public function getByExtension($ext)
+	{
+		if (!is_string($ext)) {
+			throw new \InvalidArgumentException('Extension must be a string, ' . gettype($ext) . ' given');
+		}
+
+		$this->_setQueryBuilder();
+		$this->_queryBuilder
+			->where('file.extension = ?s', [$ext])
+		;
+
+		$this->_returnAsArray = true;
+
+		return $this->_loadFromQuery();
+	}
+
+	/**
+	 * Find results based on the search term
+	 *
+	 * @param  string $term search terms
+	 * @return array|File 	Array of File objects, or a single File object
+	 */
+	public function getBySearchTerm($term)
+	{
+		// Turn the terms into an array
+		$terms = explode(' ',$term);
+
+		// Set a bunch of arrays which are used below, seems a lot but it's
+		// becasue we have to pass through an array to the sql query so we have to do it twice
+		$whereName = array();
+		$whereTag = array();
+
+		// Loop over the terms and add them to an array to implode in the query
+		foreach ($terms as $key => $term) {
+			$whereName[]  = ' name LIKE ?s';
+			$whereTag[]   = ' tag_name LIKE ?s';
+			$terms[$key] = '%' . trim($term) . '%';
+		}
+
+		$this->_setQueryBuilder();
+		$this->_queryBuilder
+			->where('(' . implode(' OR ' . $whereName) . ')', $terms)
+			->where('(' . implode(' OR ' . $whereTag) . ')', $terms, false)
+		;
+
+		$this->_returnAsArray = true;
+
+		// Return the array of results.
+		return $this->_loadFromQuery();
+	}
+
+	/**
+	 * Return all files in an array
+	 * @return Array|File|false - 	returns either an array of File objects, a
+	 * 								single file object or false
+	 */
+	public function getAll()
+	{
+		$this->_setQueryBuilder();
+
+		return $this->_loadFromQuery();
+
+	}
+
+	/**
+	 * @param User\UserInterface $user
+	 * @return bool|false|File
+	 */
+	public function getByUser(User\UserInterface $user)
+	{
+		if ($user instanceof User\AnonymousUser) {
+			return false;
+		}
+
+		$this->_setQueryBuilder();
+		$this->_queryBuilder
+			->where('file.created_by = ?i', [$user->id])
+		;
+
+		return $this->_loadFromQuery();
+
+	}
+
+	/**
+	 * Toggle whether or not to load deleted files
+	 *
+	 * @param bool $bool 	true / false as to whether to include deleted items
+	 * @return 	$this 		Loader object in order to chain the methods
+	 */
+	public function includeDeleted($bool)
+	{
+		$this->_loadDeleted = $bool;
+
+		return $this;
+	}
+	/**
+	 * @deprecated   Do not load tags from the file loader, use the TagLoader instead
+	 *
+	 * Gets the tags for a file
+	 * @param  File      $file file to load tags for
+	 * @return array     tags for file as an array
+	 */
+	public function getTagsForFile(File $file)
+	{
+		return $this->_tagLoader->getByFile($file);
+	}
+
+	/**
+	 * Sets the query builder with the appropriate SELECT and FROM statement
+	 */
+	private function _setQueryBuilder()
+	{
+		$this->_queryBuilder = $this->_queryBuilderFactory->getQueryBuilder()
+			->select([
+				'file.file_id AS id',
+				'file.url AS url',
+				'file.name AS `name`',
+				'file.extension AS extension',
+				'file.file_size AS fileSize',
+				'file.created_at AS createdAt',
+				'file.created_by AS createdBy',
+				'file.updated_at AS updatedAt',
+				'file.updated_by AS updatedBy',
+				'file.deleted_at AS deletedAt',
+				'file.deleted_by AS deletedBy',
+				'file.type_id AS typeID',
+				'file.checksum AS checksum',
+				'file.preview_url AS previewUrl',
+				'file.dimension_x AS dimensionX',
+				'file.dimension_y AS dimensionY',
+				'file.alt_text AS altText',
+				'file.duration AS duration',
+			])
+			->from('file')
+			->orderBy('file.created_at DESC')
+		;
+
+		if (!$this->_loadDeleted) {
+			$this->_queryBuilder
+				->where('file.deleted_at IS NULL');
+		}
+	}
+
+	/**
+	 * Loads the file data out of the table and loads in into a File Object.
+	 *
+	 * @return File|false return instance of the file is loaded else false
+	 */
+	protected function _loadFromQuery()
+	{
+		if (null === $this->_queryBuilder) {
+			throw new \LogicException('Cannot load files, query builder not set');
+		}
+
+		$result = $this->_queryBuilder->getQuery()->run();
+
+		if (count($result)) {
+			return $this->_loadFile($result);
+		}
+
+		$this->_queryBuilder = null;
+
+		return false;
+	}
+
+	/**
+	 * This will load file objects for the results of _load
+	 *
+	 * @param  Result $results 	Results of files that need to be loaded
+	 *
+	 * @return array|File 		array or single Page object if only one result
+	 */
+	protected function _loadFile(Result $results)
+	{
+		$files = $results->bindTo(
+			'\Message\Mothership\FileManager\File\FileProxy',
+			[$this->_tagLoader]
+		);
+
+		foreach ($results as $key => $result) {
+
+			$files[$key]->authorship->create(new DateTimeImmutable('@'.$result->createdAt), $result->createdBy);
+
+			if ($result->updatedAt) {
+				$files[$key]->authorship->update(new DateTimeImmutable('@'.$result->updatedAt), $result->updatedBy);
+			}
+
+			if ($result->deletedAt) {
+				$files[$key]->authorship->delete(new DateTimeImmutable('@'.$result->deletedAt), $result->deletedBy);
+			}
+
+			$files[$key]->file = new FileSystemFile($files[$key]->url);
+
+			// Force type to be an integer
+			$files[$key]->typeID = (int) $files[$key]->typeID;
+		}
+
+		return count($files) == 1 && !$this->_returnAsArray ? array_shift($files) : $files;
+	}
+
+	/**
+	 * @deprecated  Do not load tags from the file loader, use the tag loader directly instead
+	 *
+	 * @param File $file
+	 * @return array
+	 */
+	protected function _loadTags(File $file)
+	{
+		return $this->_tagLoader->getByFile($file);
+	}
+
+}

--- a/src/File/FileLoader.php
+++ b/src/File/FileLoader.php
@@ -13,6 +13,8 @@ use Message\Cog\DB\Result;
  * @package Message\Mothership\FileManager\File
  *
  * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Replacement for File\Loader. Note, in version 4.0.0, this will no longer extend File\Loader
  */
 class FileLoader extends Loader implements FileLoaderInterface
 {
@@ -221,6 +223,23 @@ class FileLoader extends Loader implements FileLoaderInterface
 
 		return $this;
 	}
+
+	/**
+	 * Override for method in File\Loader
+	 */
+	public function getByUnused()
+	{
+		throw new \LogicException('This method is not used and will be removed in version 4.0.0');
+	}
+
+	/**
+	 * Override for method in File\Loader
+	 */
+	public function getTagsForFile(File $file)
+	{
+		throw new \LogicException('This method is not used and will be removed in version 4.0.0');
+	}
+
 
 	/**
 	 * Sets the query builder with the appropriate SELECT and FROM statement

--- a/src/File/FileLoader.php
+++ b/src/File/FileLoader.php
@@ -157,8 +157,8 @@ class FileLoader extends Loader implements FileLoaderInterface
 
 		// Set a bunch of arrays which are used below, seems a lot but it's
 		// becasue we have to pass through an array to the sql query so we have to do it twice
-		$whereName = array();
-		$whereTag = array();
+		$whereName = [];
+		$whereTag  = [];
 
 		// Loop over the terms and add them to an array to implode in the query
 		foreach ($terms as $key => $term) {

--- a/src/File/FileLoaderInterface.php
+++ b/src/File/FileLoaderInterface.php
@@ -72,11 +72,4 @@ interface FileLoaderInterface
 	 * @return 	$this 		Loader object in order to chain the methods
 	 */
 	public function includeDeleted($bool);
-
-	/**
-	 * Gets the tags for a file
-	 * @param  File      $file file to load tags for
-	 * @return array     tags for file as an array
-	 */
-	public function getTagsForFile(File $file);
 }

--- a/src/File/FileLoaderInterface.php
+++ b/src/File/FileLoaderInterface.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Message\Mothership\FileManager\File;
+
+use Message\User\UserInterface;
+
+/**
+ * Interface FileLoaderInterface
+ * @package Message\Mothership\FileManager\File
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Interface representing a
+ */
+interface FileLoaderInterface
+{
+	public function getByID($fileID);
+
+	/**
+	 * Returns all the files of a certain file type id
+	 *
+	 * @param  int 	$typeID
+	 * @return array|File 	Array of File objects, or a single File object
+	 */
+	public function getByType($typeID);
+
+	/**
+	 * Load files by their filename
+	 *
+	 * @param string $filename
+	 * @throws \InvalidArgumentException    Throws exception if $filename is not a string
+	 *
+	 * @return array|bool|File
+	 */
+	public function getByFilename($filename);
+
+	/**
+	 * Load all files with a certain extension
+	 *
+	 * @param string $ext
+	 * @throws \InvalidArgumentException    Throws exception if $ext is not a string
+	 *
+	 * @return array|bool|File
+	 */
+	public function getByExtension($ext);
+
+	/**
+	 * Find results based on the search term
+	 *
+	 * @param  string $term search terms
+	 * @return array|File 	Array of File objects, or a single File object
+	 */
+	public function getBySearchTerm($term);
+
+	/**
+	 * Return all files in an array
+	 * @return Array|File|false - 	returns either an array of File objects, a
+	 * 								single file object or false
+	 */
+	public function getAll();
+
+	/**
+	 * @param UserInterface $user
+	 * @return mixed
+	 */
+	public function getByUser(UserInterface $user);
+
+	/**
+	 * Toggle whether or not to load deleted files
+	 *
+	 * @param bool $bool 	true / false as to whether to include deleted items
+	 * @return 	$this 		Loader object in order to chain the methods
+	 */
+	public function includeDeleted($bool);
+
+	/**
+	 * Gets the tags for a file
+	 * @param  File      $file file to load tags for
+	 * @return array     tags for file as an array
+	 */
+	public function getTagsForFile(File $file);
+}

--- a/src/File/FileProxy.php
+++ b/src/File/FileProxy.php
@@ -6,26 +6,23 @@ use Message\Cog\DB\Entity\EntityLoaderCollection;
 
 class FileProxy extends File
 {
-	protected $_loader;
+	protected $_tagLoader;
 	protected $_loaded = false;
 	
-	/**
-	 * @{inheritdoc}
-	 * @param EntityLoaderCollection $loaderCollection loaders
-	 */
-	public function __construct(Loader $loader)
+
+	public function __construct(TagLoader $tagLoader)
 	{
-		$this->_loader = $loader;
+		$this->_tagLoader = $tagLoader;
 		parent::__construct();
 	}
 
 	public function getTags()
 	{
 		if ($this->_loaded) {
-			return;
+			return parent::getTags();
 		}
 
-		$tags = $this->_loader->getTagsForFile($this);
+		$tags = $this->_tagLoader->getByFile($this);
 		
 		if ($tags !== false) {
 			$this->_tags = $this->_tags + $tags;

--- a/src/File/Loader.php
+++ b/src/File/Loader.php
@@ -231,6 +231,7 @@ class Loader implements FileLoaderInterface
 		$this->_loadDeleted = $bool;
 		return $this;
 	}
+
 	/**
 	 * Gets the tags for a file
 	 * @param  File      $file file to load tags for

--- a/src/File/Loader.php
+++ b/src/File/Loader.php
@@ -2,12 +2,17 @@
 
 namespace Message\Mothership\FileManager\File;
 
+use Message\User;
 use Message\Cog\DB\Query;
 use Message\Cog\ValueObject\DateTimeImmutable;
 use Message\Cog\Filesystem\File as FileSystemFile;
 use Message\Cog\DB\Result;
 
-class Loader
+/**
+ * @deprecated  Preserved for backwards compatibility, and will be removed in version 4.0.0. Use more efficient
+ *              FileLoader instead.
+ */
+class Loader implements FileLoaderInterface
 {
 
 	protected $_locale;
@@ -63,6 +68,60 @@ class Loader
 
 		return count($result) ? $this->getByID($result->flatten()) : false;
 
+	}
+
+	/**
+	 * Load files by their filename
+	 *
+	 * @param string $filename
+	 * @throws \InvalidArgumentException    Throws exception if $filename is not a string
+	 *
+	 * @return array|bool|File
+	 */
+	public function getByFilename($filename)
+	{
+		if (!is_string($filename)) {
+			throw new \InvalidArgumentException('Filename must be a string, ' . gettype($filename) . ' given');
+		}
+
+		$result = $this->_query->run('
+			SELECT
+				file_id
+			FROM
+				file
+			WHERE
+				`name` = ?s
+		', [$filename]);
+
+		return count($result) ? $this->getByID($result->flatten()) : false;
+	}
+
+	/**
+	 * Load all files with a certain extension
+	 *
+	 * @param string $ext
+	 * @throws \InvalidArgumentException    Throws exception if $ext is not a string
+	 *
+	 * @return array|bool|File
+	 */
+	public function getByExtension($ext)
+	{
+		if (!is_string($ext)) {
+			throw new \InvalidArgumentException('Extension must be a string, ' . gettype($ext) . ' given');
+		}
+
+		$result = $this->_query->run('
+			SELECT
+				file_id
+			FROM
+				file
+			WHERE
+				extension = ?s
+		', [$ext]);
+
+		$this->_returnAsArray = true;
+
+		return count($result) ? $this->getByID($result->flatten()) : false;
 	}
 
 	/**
@@ -139,8 +198,12 @@ class Loader
 
 	}
 
-	public function getByUser(\User $user)
+	public function getByUser(User\UserInterface $user)
 	{
+		if ($user instanceof User\AnonymousUser) {
+			return false;
+		}
+
 		$result = $this->_query->run('
 			SELECT
 				file_id
@@ -234,7 +297,7 @@ class Loader
 	protected function _loadFile(Result $results)
 	{
 		$files = $results->bindTo(
-			'\Message\Mothership\FileManager\File\FileProxy',
+			'\Message\Mothership\FileManager\File\File',
 			[$this]
 		);
 
@@ -260,6 +323,12 @@ class Loader
 
 			// Force type to be an integer
 			$files[$key]->typeID = (int) $files[$key]->typeID;
+
+			$tags = $this->_loadTags($files[$key]);
+
+			if ($tags) {
+				$files[$key]->setTags($tags);
+			}
 		}
 
 		return count($files) == 1 && !$this->_returnAsArray ? $files[0] : $files;

--- a/src/File/TagLoader.php
+++ b/src/File/TagLoader.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Message\Mothership\FileManager\File;
+
+use Message\Cog\DB;
+
+/**
+ * Class TagLoader
+ * @package Message\Mothership\FileManager\File
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Class for loading tags assigned to files
+ */
+class TagLoader
+{
+	/**
+	 * @var DB\QueryBuilderFactory
+	 */
+	private $_queryBuilderFactory;
+
+	/**
+	 * @var DB\QueryBuilder
+	 */
+	private $_queryBuilder;
+
+	public function __construct(DB\QueryBuilderFactory $queryBuilderFactory)
+	{
+		$this->_queryBuilderFactory = $queryBuilderFactory;
+	}
+
+	/**
+	 * Get tags belonging to a file
+	 *
+	 * @param File $file
+	 *
+	 * @return array
+	 */
+	public function getByFile(File $file)
+	{
+		$this->_setQueryBuilder();
+
+		$this->_queryBuilder
+			->where('file_tag.tag_id = ?i', [$file->id])
+		;
+
+		return $this->_load();
+	}
+
+	/**
+	 * Set up a new instance of the query builder with the SELECT and FROM statements set
+	 */
+	private function _setQueryBuilder()
+	{
+		$this->_queryBuilder = $this->_queryBuilderFactory
+			->getQueryBuilder()
+			->select('file_tag.tag_name')
+			->from('file_tag')
+		;
+	}
+
+	/**
+	 * Load the tags via the query builder
+	 *
+	 * @throws \LogicException    Throws exception if query builder is not set yet
+	 *
+	 * @return array
+	 */
+	private function _load()
+	{
+		if (null === $this->_queryBuilder) {
+			throw new \LogicException('Cannot load tags, query builder not set!');
+		}
+
+		$tags = $this->_queryBuilder->getQuery()->run()->flatten();
+
+		$this->_queryBuilder = null;
+
+		return $tags;
+	}
+}

--- a/src/File/TagLoader.php
+++ b/src/File/TagLoader.php
@@ -41,7 +41,7 @@ class TagLoader
 		$this->_setQueryBuilder();
 
 		$this->_queryBuilder
-			->where('file_tag.tag_id = ?i', [$file->id])
+			->where('file_tag.file_id = ?i', [$file->id])
 		;
 
 		return $this->_load();


### PR DESCRIPTION
This PR replaces the `File\Loader` class with `File\FileLoader`. The class could not have its constructor changes as Commerce and CMS both have classes that extend it, so it would be a major BC break.

### Summary

This PR:

+ Adds `File\FileLoaderInterface`, which is implemented by all file loaders, and includes new methods: `getByFilename()` and `getByExtension()`
+ Deprecates `File\Loader`
+ Adds `File\FileLoader` which is a refactored version of `File\Loader` that uses the QueryBuilder
+ Adds `File\TagLoader` for loading file tags

This PR makes https://github.com/mothership-ec/cog-mothership-file-manager/pull/84 redundant