### PR TITLE
Fix mysql query on search that was including deleted files

### DIFF
--- a/src/Controller/Listing.php
+++ b/src/Controller/Listing.php
@@ -64,8 +64,10 @@ class Listing extends \Message\Cog\Controller\Controller
 
 	public function search($term)
 	{
+		$files = $this->get('file_manager.file.loader')->getBySearchTerm($term);
+
 		return $this->render('::listing', array(
-			'files'            => $this->get('file_manager.file.loader')->getBySearchTerm($term),
+			'files'            => $files,
 			'searchTerm'       => $term,
 			'form'             => $this->_getUploadForm(),
 			'search_form'      => $this->_getSearchForm(),

--- a/src/File/FileLoader.php
+++ b/src/File/FileLoader.php
@@ -171,8 +171,7 @@ class FileLoader extends Loader implements FileLoaderInterface
 
 		$this->_queryBuilder
 			->leftJoin('file_tag', 'file.file_id = file_tag.file_id')
-			->where('(' . implode(' OR ', $whereName) . ')', $terms)
-			->where('(' . implode(' OR ', $whereTag) . ')', $terms, false)
+			->where('(' . implode(' OR ', $whereName) . ' OR ' . implode(' OR ', $whereTag) . ')', array_merge($terms, $terms))
 		;
 
 		$this->_returnAsArray = true;


### PR DESCRIPTION
The MySQL query was setting precedence to the `AND` between the delete where statement and the search term where statements, so this wraps the search term statements in brackets to ensure that no deleted files sneak into the fray  